### PR TITLE
Avoid implicit type conversion in clamp arguments

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -31,13 +31,13 @@ const GLchar* srcVertexShader[] =
   "  pos += matPVW[2]* position0.zzzz;\n"
   "  pos += matPVW[3]* position0.wwww;\n"
   "  gl_Position = pos;\n"
-  "  float lmb = clamp( dot( vec3(0.0, 0.5, 0.5), normalize(normal0.xyz)), 0, 1 );\n"
+  "  float lmb = clamp( dot( vec3(0.0, 0.5, 0.5), normalize(normal0.xyz)), 0.f, 1.f );\n"
   "  lmb = lmb * 0.5 + 0.5;\n"
   "  vsout_color0.rgb = vec3(lmb,lmb,lmb);\n"
   "  vsout_color0.a = 1.0;\n"
   "}"
  };
- 
+
 const GLchar* srcFragmentShader[] =
 {
   "precision mediump float; \n"


### PR DESCRIPTION
Hi, I've hit implicit type conversion dependent shader problem.

I guess that `clamp ( (dot(vec3, vec3) = float), ?, ?)` should be the following type arguments.

```glsl
float clamp(float, float, float)
```

I could run your shader in Ubuntu 17.04 with VMWare tools environment (mesa).

```log
$ es2_info
EGL_VERSION: 1.4 (DRI2)
EGL_VENDOR: Mesa Project
EGL_EXTENSIONS:
    EGL_CHROMIUM_sync_control, EGL_EXT_buffer_age, 
    EGL_EXT_image_dma_buf_import, EGL_KHR_cl_event2, EGL_KHR_config_attribs, 
    EGL_KHR_create_context, EGL_KHR_fence_sync, 
    EGL_KHR_get_all_proc_addresses, EGL_KHR_gl_colorspace, 
    EGL_KHR_gl_renderbuffer_image, EGL_KHR_gl_texture_2D_image, 
    EGL_KHR_gl_texture_3D_image, EGL_KHR_gl_texture_cubemap_image, 
    EGL_KHR_image, EGL_KHR_image_base, EGL_KHR_image_pixmap, 
    EGL_KHR_no_config_context, EGL_KHR_reusable_sync, 
    EGL_KHR_surfaceless_context, EGL_KHR_wait_sync, 
    EGL_MESA_configless_context, EGL_MESA_drm_image, 
    EGL_MESA_image_dma_buf_export, EGL_NOK_texture_from_pixmap, 
    EGL_WL_bind_wayland_display
EGL_CLIENT_APIS: OpenGL OpenGL_ES 
GL_VERSION: OpenGL ES 3.0 Mesa 17.0.3
GL_RENDERER: Gallium 0.4 on SVGA3D; build: RELEASE;  LLVM;
GL_EXTENSIONS:
    GL_EXT_blend_minmax, GL_EXT_multi_draw_arrays, 
    GL_EXT_texture_filter_anisotropic, GL_EXT_texture_compression_dxt1, 
    GL_EXT_texture_format_BGRA8888, GL_OES_compressed_ETC1_RGB8_texture, 
    GL_OES_depth24, GL_OES_element_index_uint, GL_OES_fbo_render_mipmap, 
    GL_OES_mapbuffer, GL_OES_rgb8_rgba8, GL_OES_standard_derivatives, 
    GL_OES_stencil8, GL_OES_texture_3D, GL_OES_texture_float, 
    GL_OES_texture_half_float, GL_OES_texture_npot, GL_OES_vertex_half_float, 
    GL_EXT_texture_sRGB_decode, GL_OES_EGL_image, GL_OES_depth_texture, 
    GL_OES_packed_depth_stencil, GL_EXT_texture_type_2_10_10_10_REV, 
    GL_OES_get_program_binary, GL_APPLE_texture_max_level, 
    GL_EXT_discard_framebuffer, GL_EXT_read_format_bgra, 
    GL_NV_fbo_color_attachments, GL_OES_EGL_image_external, GL_OES_EGL_sync, 
    GL_OES_vertex_array_object, GL_ANGLE_texture_compression_dxt3, 
    GL_ANGLE_texture_compression_dxt5, GL_EXT_texture_rg, 
    GL_EXT_unpack_subimage, GL_NV_draw_buffers, GL_NV_read_buffer, 
    GL_NV_read_depth, GL_NV_read_depth_stencil, GL_NV_read_stencil, 
    GL_EXT_draw_buffers, GL_EXT_map_buffer_range, GL_KHR_debug, 
    GL_OES_depth_texture_cube_map, GL_OES_surfaceless_context, 
    GL_EXT_color_buffer_float, GL_EXT_separate_shader_objects, 
    GL_EXT_shader_integer_mix, GL_EXT_copy_image, 
    GL_EXT_draw_elements_base_vertex, GL_EXT_texture_border_clamp, 
    GL_KHR_context_flush_control, GL_OES_copy_image, 
    GL_OES_draw_elements_base_vertex, GL_OES_texture_border_clamp, 
    GL_EXT_blend_func_extended, GL_MESA_shader_integer_functions
```


Otherwise, the following error occurred:

```log
CompiledLog: 0:13(14): error: no matching function for call to
`clamp(float, int, int)'; candidates are:
0:13(14): error:    float clamp(float, float, float)
0:13(14): error:    vec2 clamp(vec2, float, float)
0:13(14): error:    vec3 clamp(vec3, float, float)
0:13(14): error:    vec4 clamp(vec4, float, float)
0:13(14): error:    vec2 clamp(vec2, vec2, vec2)
0:13(14): error:    vec3 clamp(vec3, vec3, vec3)
0:13(14): error:    vec4 clamp(vec4, vec4, vec4)
0:13(14): error:    int clamp(int, int, int)
0:13(14): error:    ivec2 clamp(ivec2, int, int)
0:13(14): error:    ivec3 clamp(ivec3, int, int)
0:13(14): error:    ivec4 clamp(ivec4, int, int)
0:13(14): error:    ivec2 clamp(ivec2, ivec2, ivec2)
0:13(14): error:    ivec3 clamp(ivec3, ivec3, ivec3)
0:13(14): error:    ivec4 clamp(ivec4, ivec4, ivec4)
0:14(8): warning: `lmb' used uninitialized
```

How do you feel this patch?

Thanks, 